### PR TITLE
Configure smtp port

### DIFF
--- a/ckmailer.cc
+++ b/ckmailer.cc
@@ -359,6 +359,7 @@ int main(int argc, char** argv)
 	att.push_back({r["id"], r["filename"]});
             
       sendEmail(settings["smtp-server"],  // system setting
+		25,
 		"bert@hubertnet.nl", // channel setting really
 		dest,        
 		"test email", // subject
@@ -487,6 +488,7 @@ int main(int argc, char** argv)
 	
 	if(1)
 	sendEmail(settings["smtp-server"],  // system setting
+		  25,
 		  settings["sender-email"], // channel setting really
 		  eget(q, "destination"),        
 		  eget(q, "subject"), // subject

--- a/ckmailer.cc
+++ b/ckmailer.cc
@@ -105,7 +105,9 @@ int main(int argc, char** argv)
   signal(SIGPIPE, SIG_IGN); // every TCP application needs this
   argparse::ArgumentParser args("bmailer", "0.0");
   map<string, string> settings;
+  map<string, int> intSettings;
   args.add_argument("--smtp-server").help("IP address of SMTP smart host. If empty, no mail will get sent").default_value("").store_into(settings["smtp-server"]);
+  args.add_argument("--smtp-port").help("Port of SMTP smart host").scan<'d', int>().default_value(25).store_into(intSettings["smtp-port"]);
   args.add_argument("--imap-server").help("IMAP server to query").default_value("").store_into(settings["imap-server"]);
   args.add_argument("--imap-user").help("IMAP server to query").default_value("").store_into(settings["imap-user"]);
   args.add_argument("--imap-password").help("IMAP server to query").default_value("").store_into(settings["imap-password"]);
@@ -359,7 +361,7 @@ int main(int argc, char** argv)
 	att.push_back({r["id"], r["filename"]});
             
       sendEmail(settings["smtp-server"],  // system setting
-		25,
+		intSettings["smtp-port"],
 		"bert@hubertnet.nl", // channel setting really
 		dest,        
 		"test email", // subject
@@ -488,7 +490,7 @@ int main(int argc, char** argv)
 	
 	if(1)
 	sendEmail(settings["smtp-server"],  // system setting
-		  25,
+		  intSettings["smtp-port"],
 		  settings["sender-email"], // channel setting really
 		  eget(q, "destination"),        
 		  eget(q, "subject"), // subject

--- a/ckmserv.cc
+++ b/ckmserv.cc
@@ -363,6 +363,7 @@ int main(int argc, char** argv)
     }
     tp.getLease()->addValue({{"timestamp", time(0)}, {"action", "user-invite"}, {"userId", userId}, {"email", email}, {"created", created}, {"lang", lang}}, "log");
     sendEmail("10.0.0.2",  // system setting
+	      25,
 	      "bert@hubertnet.nl", // channel setting really
 	      email,
 	      subject,

--- a/support.cc
+++ b/support.cc
@@ -122,7 +122,7 @@ bool endsWith(const std::string& str, const std::string& suffix) {
 }
 
 
-void sendEmail(const std::string& server, const std::string& from, const std::string& to, const std::string& subject, const std::string& textBody, const std::string& htmlBody, const std::string& bcc, const std::string& envelopeFrom, const std::vector<std::pair<std::string, std::string>>& att,
+void sendEmail(const std::string& server, const int serverPort, const std::string& from, const std::string& to, const std::string& subject, const std::string& textBody, const std::string& htmlBody, const std::string& bcc, const std::string& envelopeFrom, const std::vector<std::pair<std::string, std::string>>& att,
 	       const std::vector<std::pair<std::string, std::string>>& headers)
 {
   string rEnvelopeFrom = envelopeFrom.empty() ? from : envelopeFrom;
@@ -132,7 +132,7 @@ void sendEmail(const std::string& server, const std::string& from, const std::st
     throw std::runtime_error("Illegal character in from or to address");
   }
 
-  ComboAddress mailserver(server, 25);
+  ComboAddress mailserver(server, serverPort);
   Socket s(mailserver.sin4.sin_family, SOCK_STREAM);
 
   SocketCommunicator sc(s);

--- a/support.hh
+++ b/support.hh
@@ -4,7 +4,7 @@
 #include <unordered_map>
 #include <set>
 #include "nonblocker.hh"
-void sendEmail(const std::string& server, const std::string& from, const std::string& to, const std::string& subject, const std::string& textBody, const std::string& htmlBody, const std::string& bcc="", const std::string& envelopeFrom="", const std::vector<std::pair<std::string, std::string>>& att={},
+void sendEmail(const std::string& server, const int serverPort, const std::string& from, const std::string& to, const std::string& subject, const std::string& textBody, const std::string& htmlBody, const std::string& bcc="", const std::string& envelopeFrom="", const std::vector<std::pair<std::string, std::string>>& att={},
 	       const std::vector<std::pair<std::string, std::string>>& headers={});
 uint64_t getRandom64();
 std::string getLargeId();


### PR DESCRIPTION
Make SMTP port configurable, for both `ckmserv` and `ckm`.

Todo: `--save-settings` and `getSetting` do not support it yet. Will do so if contributions like this are ok...