### PR TITLE
Add per-channel Atom feed with 10 most recent messages

### DIFF
--- a/partials/channel.html
+++ b/partials/channel.html
@@ -6,6 +6,10 @@ email: ''
 }"
 {% endblock %}
 
+{% block extrameta %}
+<link rel="alternate" type="application/atom+xml" href="feed.xml?channelId={{channelId}}">
+{% endblock %}
+
 {% block javascript %}
 {{ super() }}
 {% endblock %}

--- a/partials/feed.xml
+++ b/partials/feed.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ c.name }}</title>
+  <subtitle>{{ c.description }}</subtitle>
+  <link rel="self" href="{{ base }}/feed.xml?channelId={{ c.id }}" />
+  <link rel="alternate" href="{{ base }}/channel.html?channelId={{ c.id }}" />
+  <id>{{ base }}/channel.html?channelId={{ c.id }}</id>
+  <updated>{{ timestamp }}</updated>
+  <author><name>{{ author }}</name></author>
+
+  {% for p in posts %}
+  <entry>
+    <title>{{ p.subject }}</title>
+    <link href="{{ base }}/msg/{{ p.msgId }}" />
+    <id>{{ base }}/msg/{{ p.msgId }}</id>
+    <updated>{{ p.launched }}</updated>
+    <content type="html">{{ p.webversion }}</content>
+  </entry>
+  {% endfor %}
+</feed>


### PR DESCRIPTION
This adds an Atom feed containing the web version of each message, so including base64-encoded images and without the subscribe/unsubscribe verbiage.

This is related to #14 except that it uses Atom instead of RSS; Atom should be supported by all clients as well, and is slightly more thoroughly standardized in RFCs and such. Feed readers can be pointed either at the channel page or at the feed URL directly.

Tried with Liferea and Thunderbird.