### PR TITLE
Parse subcommands and arguments with argparse

### DIFF
--- a/ckmailer.cc
+++ b/ckmailer.cc
@@ -592,6 +592,7 @@ int main(int argc, char** argv)
     if (imap_command["--active"] == true && !handled.empty()) {
       imapMove(ComboAddress(settings["imap-server"], 993), "bmailer", settings["imap-password"], handled);
     }
-
+  } else {
+    cout<<args<<endl;
   }
 }

--- a/ckmailer.cc
+++ b/ckmailer.cc
@@ -211,7 +211,6 @@ int main(int argc, char** argv)
 
   argparse::ArgumentParser imap_command("imap");
   imap_command.add_description("Imap management");
-  imap_command.add_argument("commands").help("msg commands").default_value(vector<string>()).remaining();
   imap_command.add_argument("--active").help("act on messages, don't just observe").flag();
   args.add_subparser(imap_command);
 
@@ -552,8 +551,7 @@ int main(int argc, char** argv)
     }
   }
   else if(args.is_subcommand_used(imap_command)) {
-    
-    auto cmds = imap_command.get<std::vector<std::string>>("commands");
+
     auto uhdrs = imapGetMessages(ComboAddress(settings["imap-server"], 993),
 				 settings["imap-user"],
 				 settings["imap-password"]);


### PR DESCRIPTION
This moves parsing of sub-subcommands into argparse, both for consistency and to make subcommand parsing a bit more robust.

As an added benefit, this makes it so that the `--help` feature can discover the different sub-subcommands.

For example, with this change, `ckm queue` with no sub-subcommand prints:

```
Usage: queue [--help] [--version] {list,ls,run}

Queue management

Optional arguments:
  -h, --help     shows help message and exits 
  -v, --version  prints version information and exits 

Subcommands:
  list          List all queued messages
  ls            List all queued messages
  run           Send all messages in the queue
```

Before, this was UB:

```
Got queue commands: []
/nix/store/ZS2GQ6FKGLRD28G1NXLB8WAQQ37CDC2Z-gcc-14-20241116/include/c++/14-20241116/bits/stl_vector.h:1130: constexpr std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; reference = std::__cxx11::basic_string<char>&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
Aborted (core dumped)
```

As a downside, the `ckm` `main` function is slightly longer.